### PR TITLE
remove contact form and tab

### DIFF
--- a/layouts/partials/footer/index.html
+++ b/layouts/partials/footer/index.html
@@ -1,44 +1,24 @@
 <!-- Footer -->
 {{ $data := index .Site.Data .Site.Language.Lang }}
 <footer id="footer">
-    {{ with $data.contactinfo.contactformaction }}
+    {{ with $data.contactinfo.address }}
+    <section class="alt">
+        <h3>{{ i18n "CONTACT_ADDRESS" . }}</h3>
+        <p>
+            {{ range $i, $e := . }}
+                {{ if $i }} <br/> {{ end }} {{ .line }}
+            {{ end }}
+        </p>
+    </section>
+    {{ end }}
+    {{ with $data.contactinfo.phone }}
     <section>
-        <form method="post" action="{{ . }}">
-            <div class="field">
-                <label for="name">{{ i18n "CONTACT_FORM_FIELD_NAME" . }}</label>
-                <input type="text" name="name" id="name" />
-            </div>
-            <div class="field">
-                <label for="email">{{ i18n "CONTACT_FORM_FIELD_EMAIL" . }}</label>
-                <input type="text" name="email" id="email" />
-            </div>
-            <div class="field">
-                <label for="message">{{ i18n "CONTACT_FORM_FIELD_MESSAGE" . }}</label>
-                <textarea name="message" id="message" rows="3"></textarea>
-            </div>
-            <ul class="actions">
-                <li><input type="submit" value='{{ i18n "CONTACT_FORM_SUBMIT_SEND_MESSAGE" . }}' /></li>
-            </ul>
-        </form>
+        <h3>{{ i18n "CONTACT_PHONE" . }}</h3>
+        <p><a href="tel:{{ . }}">{{ . }}</a></p>
     </section>
     {{ end }}
     <section class="split contact">
-        {{ with $data.contactinfo.address }}
-        <section class="alt">
-            <h3>{{ i18n "CONTACT_ADDRESS" . }}</h3>
-            <p>
-                {{ range $i, $e := . }}
-                    {{ if $i }} <br/> {{ end }} {{ .line }}
-                {{ end }}
-            </p>
-        </section>
-        {{ end }}
-        {{ with $data.contactinfo.phone }}
-        <section>
-            <h3>{{ i18n "CONTACT_PHONE" . }}</h3>
-            <p><a href="tel:{{ . }}">{{ . }}</a></p>
-        </section>
-        {{ end }}
+        
         {{ with $data.contactinfo.email }}
         <section>
             <h3>{{ i18n "CONTACT_EMAIL" . }}</h3>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,15 +2,13 @@
 {{ $data := index .Site.Data .Site.Language.Lang }}
 <nav id="nav">
     <ul class="links">
-        <li class="active"><a href='{{ "/" | relLangURL }}'>Home</a></li>
-        <li class="active"><a href='/post/overview'>Course overview</a></li>
-        <li class="active"><a href='/post/team'>Meet the team</a></li>
-        <li class="active"><a href='/post/practical_info'>Practical info</a></li>
-        <li class="active"><a href='/post/register'>Register</a></li>
-        <li class="active"><a href='/post/sponsors'>Partners</a></li>
-        {{ with $data.contactinfo }}
-        <li><a href='{{ "#footer" | relLangURL }}'>{{ i18n "NAV_CONTACT" . }}</a></li>
-        {{ end }}
+        <li><a href='{{ "/" | relLangURL }}'>Home</a></li>
+        <li><a href='/post/overview'>Course overview</a></li>
+        <li><a href='/post/team'>Meet the team</a></li>
+        <li><a href='/post/practical_info'>Practical info</a></li>
+        <li><a href='/post/register'>Register</a></li>
+        <li><a href='/post/sponsors'>Partners</a></li>
+        
         {{ if .IsTranslated }}
         {{ range .AllTranslations }}
         <li {{if eq ($.Site.Language) (.Language)}}class="active"{{end}}><a href='{{ .Permalink }}'>{{ .Language.LanguageName }}</a></li>

--- a/public/index.html
+++ b/public/index.html
@@ -73,10 +73,6 @@
         <li class="active"><a href='/post/practical_info'>Practical info</a></li>
         <li class="active"><a href='/post/register'>Register</a></li>
         <li class="active"><a href='/post/sponsors'>Partners</a></li>
-        
-        <li><a href='/#footer'>Contact</a></li>
-        
-        
     </ul>
     
     <ul class="icons">

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -3999,7 +3999,7 @@
 			-webkit-flex-shrink: 1;
 			-ms-flex-shrink: 1;
 			flex-shrink: 1;
-			padding: 4rem 4rem 2rem 4rem ;
+			padding: 4rem 4rem 2rem 8rem ;
 			border-left: solid 2px #e2e2e2;
 		}
 


### PR DESCRIPTION
Removes contact form and tab for simplicity (addresses (issue #1)[https://github.com/reconhub/ESCAIDE_2019_workshop/issues/1])

Notes: 
- removed contact tab from the navbar but not 100% sure i removed the actual page (shouldn't be a problem bc there's no way to get there other than typing in the URL)
- removed the 'active' styling from the navbar because it looked a bit empty without the contact link (could change this!)
- changed the layout of the footer to compensate for missing form (see below)
